### PR TITLE
fix: update gamestages integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,8 @@ dependencies {
 	deobfCompile "com.shinoow.abyssalcraft:AbyssalCraft:1.12.2-1.9.4.10"
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.0.8"
 	//deobfCompile "better-questing:BetterQuesting:1.3.180"
-	deobfCompile "net.darkhax.bookshelf:Bookshelf-1.12.2:2.2.458"
-    deobfCompile "net.darkhax.gamestages:GameStages-1.12.2:1.0.70"
+	deobfCompile "net.darkhax.bookshelf:Bookshelf-1.12.2:2.3.556"
+    deobfCompile "net.darkhax.gamestages:GameStages-1.12.2:2.0.91:deobf"
 }
 
 version = "${props.mc_version}-${props.aci_version}"

--- a/src/main/java/com/shinoow/acintegration/integrations/gamestages/ACGS.java
+++ b/src/main/java/com/shinoow/acintegration/integrations/gamestages/ACGS.java
@@ -2,7 +2,7 @@ package com.shinoow.acintegration.integrations.gamestages;
 
 import java.util.Map;
 
-import net.darkhax.gamestages.capabilities.PlayerDataHandler;
+import net.darkhax.gamestages.GameStageHelper;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
@@ -52,7 +52,7 @@ public class ACGS implements IACPlugin {
 		String requiredStage = RITUAL_MAP.get(event.getRitual().getUnlocalizedName().substring(10));
 
 		if(requiredStage != null && !requiredStage.isEmpty())
-			if(!PlayerDataHandler.getStageData(event.getEntityPlayer()).hasUnlockedStage(requiredStage)){
+			if(!GameStageHelper.getPlayerData(event.getEntityPlayer()).hasStage(requiredStage)){
 				event.setCanceled(true);
 				if(event.getWorld().isRemote)
 					event.getEntityPlayer().sendMessage(new TextComponentString("You cannot perform this ritual yet."));


### PR DESCRIPTION
- Updates support for 2.0
- Not sure if you wanted backward support on this one (I guess you might), but 2.0 most people should be using now. As it's the improved version and contains a tonne of fixes.
- Might need to set the version as needed for the optional mod deps.

You may of already fixed this. But I had this fixed this morning before the Maven went down. So I'll send it anyhow to remind ya 😆 _Love ya!_